### PR TITLE
Added endpoints to get details on stops and trips

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,7 +68,7 @@ let args = yargs
     .demandCommand()
     .option('verbose', {
         alias: 'v',
-        default: false
+        default: true
     })
     .option('color', {
         alias: 'c',
@@ -93,7 +93,7 @@ app.use(bodyParser.raw({
 
 // <editor-fold desc="ROUTES">
 
-app.use("/vdv/import", expressAuth({users: config.users}));
+//app.use("/vdv/import", expressAuth({users: config.users}));
 app.use("/firebase", expressAuth({users: config.users}));
 
 
@@ -138,6 +138,9 @@ app.group("/geojson", (router) => {
 
     router.get("/lines/all", v1Lines.fetchAllLinesAction);
     router.get("/lines", v1Lines.fetchLinesAction);
+    
+    router.get("/trips/:tripIds", v1Lines.fetchTrips);
+    
 });
 
 app.group("/app", (router) => {

--- a/app.js
+++ b/app.js
@@ -68,7 +68,7 @@ let args = yargs
     .demandCommand()
     .option('verbose', {
         alias: 'v',
-        default: true
+        default: false
     })
     .option('color', {
         alias: 'c',
@@ -93,7 +93,7 @@ app.use(bodyParser.raw({
 
 // <editor-fold desc="ROUTES">
 
-//app.use("/vdv/import", expressAuth({users: config.users}));
+app.use("/vdv/import", expressAuth({users: config.users}));
 app.use("/firebase", expressAuth({users: config.users}));
 
 

--- a/app.js
+++ b/app.js
@@ -138,9 +138,10 @@ app.group("/geojson", (router) => {
 
     router.get("/lines/all", v1Lines.fetchAllLinesAction);
     router.get("/lines", v1Lines.fetchLinesAction);
-    
+
     router.get("/trips/:tripIds", v1Lines.fetchTrips);
-    
+    router.get("/stops/:stopIds", v1Stops.fetchStops);
+
 });
 
 app.group("/app", (router) => {

--- a/database/schema/data.sql
+++ b/database/schema/data.sql
@@ -726,7 +726,7 @@ CREATE TABLE rec_ort (
     ort_pos_laenge bigint,
     ort_pos_breite bigint,
     ort_pos_hoehe bigint,
-    ort_richtung SMALLINT
+    ort_richtung SMALLINT,
     ort_druckname VARCHAR(40),
     richtungswechsel SMALLINT
 );

--- a/endpoint/geojson/lines.js
+++ b/endpoint/geojson/lines.js
@@ -88,6 +88,9 @@ module.exports.fetchTrips = function (req, res) {
         })
         .then(trips => {
 
+            if (trips.length === 0)
+                return [];
+
             let outputFormat = config.coordinate_wgs84;
             let stopFinder = new StopFinder(outputFormat);
 

--- a/endpoint/geojson/lines.js
+++ b/endpoint/geojson/lines.js
@@ -6,6 +6,7 @@ const logger = require("../../util/logger");
 const utils = require("../../util/utils");
 
 const LinesFinder = require("../../model/line/LinesFinder");
+const StopFinder = require("../../model/busstop/BusStops");
 
 module.exports.fetchAllLinesAction = function (req, res) {
     database.connect()
@@ -68,3 +69,53 @@ module.exports.fetchLinesAction = function (req, res) {
             utils.handleError(error)
         })
 };
+
+module.exports.fetchTrips = function (req, res) {
+
+    database.connect()
+        .then(client => {
+
+            return Promise.resolve()
+                .then(rows => {
+
+                    let outputFormat = config.coordinate_wgs84;
+                    let stopFinder = new StopFinder(outputFormat);
+
+                    let tripIds = req.params.tripIds || {};
+                    tripIds = tripIds.split(",");
+
+                    return stopFinder.getTrips(tripIds);
+
+                })
+                .then(rows => {
+
+                    let indexedTrips = {};
+
+                    rows.forEach(function (item) {
+                        
+                        let tripId = item.tripId;
+                        
+                        if (indexedTrips[tripId] === undefined)
+                            indexedTrips[tripId] = [];
+
+                        indexedTrips[tripId].push(item);
+
+                    });
+
+                    res.status(200).jsonp(indexedTrips);
+
+                })
+                .catch(error => {
+                    logger.error(error);
+                    res.status(500).jsonp({success: false, error: error});
+                });
+
+        })
+        .catch(error => {
+            logger.error(`Error acquiring client: ${error}`);
+
+            utils.respondWithError(res, error);
+            utils.handleError(error);
+        });
+
+}

--- a/endpoint/geojson/stops.js
+++ b/endpoint/geojson/stops.js
@@ -113,3 +113,28 @@ module.exports.nextBusesAtStop = function (req, res) {
             res.status(500).jsonp({success: false, error: error})
         })
 };
+
+module.exports.fetchStops = function(req, res) {
+
+    return Promise.resolve()
+        .then(() => {
+
+            let outputFormat = config.coordinate_wgs84;
+
+            let stopIds = req.params.stopIds.split(",");
+            let stopFinder = new StopFinder(outputFormat);
+
+            return stopFinder.getStopsByIds(stopIds)
+
+        })
+        .then(rows => {
+
+            res.status(200).jsonp(rows);
+
+        })
+        .catch(error => {
+            logger.error(error);
+            res.status(500).jsonp({success: false, error: error})
+        });
+
+};

--- a/model/busstop/BusStops.js
+++ b/model/busstop/BusStops.js
@@ -108,6 +108,28 @@ module.exports = class BusStops {
             });
     }
 
+    getStopsByIds(stopIds) {
+        return Promise.resolve(
+            `SELECT ro.onr_typ_nr,
+                ro.ort_nr,
+                ro.ort_name,
+                ro.ort_ref_ort_name,
+                ST_AsGeoJSON(ro.the_geom) as json_geom
+            FROM data.rec_ort AS ro
+            WHERE ro.ort_nr IN ('${stopIds.join("','")}')`
+        )
+        .then(sql => connection.query(sql))
+        .then(results => {
+
+            results.rows.forEach(function (item, idx) {
+                results.rows[idx]['json_geom'] = JSON.parse(item.json_geom);
+            });
+
+            return results.rows;
+
+        });
+    }
+
     getStopsForApp(tripId, stopIds, timeFrom, timeTo) {
         const reducer = (accumulator, currentValue) => accumulator + ', '  + currentValue;
         return Promise.resolve(`
@@ -125,9 +147,9 @@ module.exports = class BusStops {
                 return results.rows;
             });
     }
-    
+
     getTrips(tripIds) {
-        
+
         return Promise.resolve(`
             SELECT
                 rf.trip AS "tripId",
@@ -146,7 +168,7 @@ module.exports = class BusStops {
         )
         .then(sql => connection.query(sql))
         .then(results => results.rows);
-        
+
     }
-    
+
 };


### PR DESCRIPTION
This pull request adds a couple of endpoints able to retrieve details on stops and trips:

* `/geojson/stops/:stopIds`
* `/geojson/trips/:tripIds`

accepted arguments can be a single stop/trip id or multiple ones separated by comma "," character (for example: `https://realtimetest.opensasa.info/geojson/trips/1939,1999` or `https://realtimetest.opensasa.info/geojson/stops/5266,5267,5268,5182`) to allow querying multiple elements in a single request.

Stops endpoint returns a plain javascript array, trips endpoint returns an indexed javascript object whose index is the trip id itself. In case one of the argument is a non-existing stop/trip id, it is just ignored and will not be reported in the results.
